### PR TITLE
containerd: configure with an in-cluster cache

### DIFF
--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -2,7 +2,16 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  extraMounts: &registry
+  - hostPath: ./registry.d
+    containerPath: /etc/containerd/registry.d
 - role: worker
+  extraMounts: *registry
 networking:
   disableDefaultCNI: true
   kubeProxyMode: "none"
+containerdConfigPatches:
+- |-
+  # Path manually-populated on each node, with `_default/hosts.toml` pointing to a cluster-local pull-through cache
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/registry.d"

--- a/oci_cache.py
+++ b/oci_cache.py
@@ -1,0 +1,96 @@
+"""A caching, pull-through OCI image cache.
+
+`ociregistry` requires neither changes to image URLs, nor per-registry configuration,
+making it the lowest-touch option I could find.
+
+`containerd` is configured to use the registry through the snippet in `kind-config.yaml`,
+which refers to `registry.d/_default`.
+"""
+
+from collections.abc import Sequence
+
+import pulumi
+import pulumi_kubernetes as k8s
+
+from utils import http_get
+
+
+def deploy(
+    cfg: pulumi.Config, *,
+    depends_on: Sequence[pulumi.Resource] = (),
+) -> tuple[k8s.apps.v1.Deployment, k8s.core.v1.Service]:
+    """Deploy `ociregistry`.
+
+    A persistent volume is created for the service, but (so far) no care is given to
+    making the cache persist across cluster creation/destruction.
+    """
+    ns = k8s.core.v1.Namespace(
+        "oci-cache",
+        # don't use automatic naming, as the containerd config depends on the name
+        metadata = k8s.meta.v1.ObjectMetaArgs(name = "oci-cache"),
+    )
+
+    labels = { "app": "oci-cache" }
+    meta = k8s.meta.v1.ObjectMetaArgs(
+        namespace = ns.metadata.name,
+        labels = labels,
+    )
+
+    pvc = k8s.core.v1.PersistentVolumeClaim(
+        "oci-cache",
+        metadata = meta,
+        spec = {
+            "access_modes": ("ReadWriteOncePod", ),
+            "resources": { "requests": { "storage": "2Gi" } },
+        },
+    )
+
+    # TODO: setup mTLS between containerd and ociregistry?
+    dpl = k8s.apps.v1.Deployment(
+        "ociregistry",
+        metadata = meta,
+        opts = pulumi.ResourceOptions(depends_on = depends_on),
+        spec = k8s.apps.v1.DeploymentSpecArgs(
+            replicas = 1,
+            selector = k8s.meta.v1.LabelSelectorArgs(match_labels = labels),
+            template = k8s.core.v1.PodTemplateSpecArgs(
+                metadata = k8s.meta.v1.ObjectMetaArgs(labels = labels),
+                spec = k8s.core.v1.PodSpecArgs(
+                    containers = [ k8s.core.v1.ContainerArgs(
+                        name = "ociregistry",
+                        image = "quay.io/appzygy/ociregistry:1.8.2",
+                        ports = [ k8s.core.v1.ContainerPortArgs(
+                            name = "http",
+                            container_port = 8080,
+                        ) ],
+                        liveness_probe = http_get("/health"),
+                        readiness_probe = http_get("/health"),
+                    ) ],
+                    volumes = [ k8s.core.v1.VolumeArgs(
+                        name = "images",
+                        persistent_volume_claim = k8s.core.v1.PersistentVolumeClaimVolumeSourceArgs(
+                            claim_name = pvc.metadata.name,
+                            read_only = False,
+                        ),
+                    ) ],
+                ),
+            ),
+        ),
+    )
+
+    svc = k8s.core.v1.Service(
+        "oci-cache",
+        # don't use automatic naming, as the containerd config depends on the name
+        # FIXME find official API surface for this
+        metadata = k8s.meta.v1.ObjectMetaArgs(name = "oci-cache", **meta.__dict__),
+        spec = k8s.core.v1.ServiceSpecArgs(
+            type = "ClusterIP",
+            ports = [ k8s.core.v1.ServicePortArgs(
+                port = 80,
+                target_port = "http",
+            ) ],
+            selector = labels,
+        ),
+    )
+
+    return (dpl, svc)

--- a/readme.org
+++ b/readme.org
@@ -1,11 +1,10 @@
 * initial setup
 ** setup shell, cluster, dependencies
 - =nix develop= to have the necessary tools
-- =docker pull = to prefetch the Cilium image
 - =kind create cluster --config kind-config.yaml=
-- pre-load some necessary container images: Cilium for networking, and the Hickory DNS server:]
+- pre-load some necessary container images: Cilium for networking, and the Hickory DNS server:
 #+BEGIN_SRC sh
-  for img in quay.io/cilium/cilium:v1.17.2 docker.io/hickorydns/hickory-dns:latest docker.io/busybox:latest; do
+  for img in quay.io/cilium/cilium:v1.17.2 docker.io/hickorydns/hickory-dns:latest docker.io/busybox:latest quay.io/appzygy/ociregistry:1.8.2; do
       docker pull $img
       kind load docker-image $img
   done

--- a/registry.d/_default/hosts.toml
+++ b/registry.d/_default/hosts.toml
@@ -1,0 +1,3 @@
+[host."http://oci-cache.oci-cache.svc.cluster.local"]
+  capabilities = ["pull", "resolve"]
+  skip_verify = true


### PR DESCRIPTION
- [x] Setup in-cluster cache on `oci-cache.oci-cache.svc.cluster.local`
- [ ] Configure `ociregistry` into using TLS when pulling from upstream
